### PR TITLE
Add missing cast

### DIFF
--- a/firmware/adxl345.cpp
+++ b/firmware/adxl345.cpp
@@ -50,9 +50,9 @@ void ADXL345::readAccel(int *x, int *y, int *z) {
 
   // each axis reading comes in 10 bit resolution, ie 2 bytes.  Least Significat Byte first!!
   // thus we are converting both bytes in to one int
-  *x = (((int)_buff[1]) << 8) | _buff[0];   
-  *y = (((int)_buff[3]) << 8) | _buff[2];
-  *z = (((int)_buff[5]) << 8) | _buff[4];
+  *x = (int16_t)(((int)_buff[1]) << 8) | _buff[0];   
+  *y = (int16_t)(((int)_buff[3]) << 8) | _buff[2];
+  *z = (int16_t)(((int)_buff[5]) << 8) | _buff[4];
 }
 
 void ADXL345::get_Gxyz(double *xyz){


### PR DESCRIPTION
Raw acceleration values in ADXL345 registers are 16-bit signed integer. Most Arduino use 16-bit AVR and no casting is required. Particle/Spark MCU is 32-bit so we need an explicit cast so the sign bit is at the right position. This will fix reading acceleration values > 32767 instead of negative acceleration.
